### PR TITLE
Move dependency specifications to deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:deps
+ {org.clojure/clojure    {:mvn/version "1.7.0"}
+  org.yaml/snakeyaml     {:mvn/version "1.23"}
+  org.flatland/ordered   {:mvn/version "1.5.7"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
-{:deps
+{:paths ["src/clojure" "src/java"]
+ :deps
  {org.clojure/clojure    {:mvn/version "1.7.0"}
   org.yaml/snakeyaml     {:mvn/version "1.23"}
   org.flatland/ordered   {:mvn/version "1.5.7"}}}

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,6 @@
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java"]
   :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
-  :dependencies
-  [[org.clojure/clojure "1.7.0"]
-   [org.yaml/snakeyaml "1.23"]
-   [org.flatland/ordered "1.5.7"]])
+  :plugins [[lein-tools-deps "0.4.3"]]
+  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
+  :lein-tools-deps/config {:config-files [:project]})


### PR DESCRIPTION
I’ve attempted to explain the rationale in detail in `project.clj`, sort-of literate-programming style. If the maintainers would prefer that such explication be in the commit message rather than the file, I’d be happy to move it.