### PR TITLE
Bump SnakeYAML and Expose Parse Options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,6 @@
   :java-source-paths ["src/java"]
   :javac-options ["-target" "1.7" "-source" "1.7" "-Xlint:-options"]
   :dependencies
-  [[org.yaml/snakeyaml "1.25"]
+  [[org.yaml/snakeyaml "1.26"]
    [org.flatland/ordered "1.5.9"]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.1"]]}})

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -199,3 +199,12 @@ the-bin: !!binary 0101")
   (testing "emoji in comments are OK too"
     (let [yaml "# 💣 emoji in a comment\n42"]
       (is (= 42 (parse-string yaml))))))
+
+(def too-many-aliases
+  (->> (range 51)
+       (map #(str "b" % ": *a"))
+       (cons "a: &a [\"a\",\"a\"]")
+       (string/join "\n")))
+
+(deftest too-many-aliases-works
+  (is (parse-string too-many-aliases)))

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -208,7 +208,7 @@ the-bin: !!binary 0101")
        (string/join "\n")))
 
 (deftest max-aliases-for-collections-works
-  (is (thrown? YAMLException (parse-string too-many-aliases)))
+  (is (thrown-with-msg? YAMLException #"Number of aliases" (parse-string too-many-aliases)))
   (is (parse-string too-many-aliases :max-aliases-for-collections 51)))
 
 (def recursive-yaml "
@@ -218,5 +218,5 @@ the-bin: !!binary 0101")
 ")
 
 (deftest allow-recursive-works
-  (is (thrown? YAMLException (parse-string recursive-yaml)))
+  (is (thrown-with-msg? YAMLException #"Recursive" (parse-string recursive-yaml)))
   (is (parse-string recursive-yaml :allow-recursive-keys true)))


### PR DESCRIPTION
I made this change in three commits because it demonstrates that this is a breaking change. All the tests pass on d590965 and bumping to SnakeYAML 1.26 on f385f74 (even though it is a minor version bump) causes the test to fail.

SnakeYAML 1.26 patches [CVE-2017-18640](https://nvd.nist.gov/vuln/detail/CVE-2017-18640), which resulted in `LoaderOptions` adding `setMaxAliasesForCollections` and `setAllowRecursiveKeys` to control the amount of aliases SnakeYAML will attempt to parse and whether it allows recursive keys. This PR exposes those options to `parse-string` via `:max-aliases-for-collections` and `:allow-recursive-keys`.