### PR TITLE
Expose Allow Duplicate Key Loader Option

### DIFF
--- a/src/clojure/clj_yaml/core.clj
+++ b/src/clojure/clj_yaml/core.clj
@@ -32,19 +32,22 @@
   (LoaderOptions.))
 
 (defn ^LoaderOptions make-loader-options
-  [& {:keys [max-aliases-for-collections allow-recursive-keys]}]
+  [& {:keys [max-aliases-for-collections allow-recursive-keys allow-duplicate-keys]}]
   (let [loader (default-loader-options)]
     (when max-aliases-for-collections
       (.setMaxAliasesForCollections loader max-aliases-for-collections))
     (when allow-recursive-keys
       (.setAllowRecursiveKeys loader allow-recursive-keys))
+    (when (instance? Boolean allow-duplicate-keys)
+      (.setAllowDuplicateKeys loader allow-duplicate-keys))
     loader))
 
 (defn ^Yaml make-yaml
   "Make a yaml encoder/decoder with some given options."
-  [& {:keys [dumper-options unsafe mark max-aliases-for-collections allow-recursive-keys]}]
+  [& {:keys [dumper-options unsafe mark max-aliases-for-collections allow-recursive-keys allow-duplicate-keys]}]
   (let [loader (make-loader-options :max-aliases-for-collections max-aliases-for-collections
-                                    :allow-recursive-keys allow-recursive-keys)
+                                    :allow-recursive-keys allow-recursive-keys
+                                    :allow-duplicate-keys allow-duplicate-keys)
         ^BaseConstructor constructor
         (if unsafe (Constructor. loader)
             (if mark
@@ -146,9 +149,10 @@
          (encode data)))
 
 (defn parse-string
-  [^String string & {:keys [unsafe mark keywords max-aliases-for-collections allow-recursive-keys] :or {keywords true}}]
+  [^String string & {:keys [unsafe mark keywords max-aliases-for-collections allow-recursive-keys allow-duplicate-keys] :or {keywords true}}]
   (decode (.load (make-yaml :unsafe unsafe
                             :mark mark
                             :max-aliases-for-collections max-aliases-for-collections
-                            :allow-recursive-keys allow-recursive-keys)
+                            :allow-recursive-keys allow-recursive-keys
+                            :allow-duplicate-keys allow-duplicate-keys)
                  string) keywords))

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -3,7 +3,8 @@
             [clojure.string :as string]
             [clj-yaml.core :refer [parse-string unmark generate-string]])
   (:import [java.util Date]
-           (org.yaml.snakeyaml.error YAMLException)))
+           (org.yaml.snakeyaml.error YAMLException)
+           (org.yaml.snakeyaml.constructor DuplicateKeyException)))
 
 (def nested-hash-yaml
   "root:\n  childa: a\n  childb: \n    grandchild: \n      greatgrandchild: bar\n")
@@ -220,3 +221,12 @@ the-bin: !!binary 0101")
 (deftest allow-recursive-works
   (is (thrown-with-msg? YAMLException #"Recursive" (parse-string recursive-yaml)))
   (is (parse-string recursive-yaml :allow-recursive-keys true)))
+
+(def duplicate-keys-yaml "
+a: 1
+a: 1
+")
+
+(deftest allow-recursive-works
+  (is (parse-string duplicate-keys-yaml))
+  (is (thrown-with-msg? DuplicateKeyException #"found duplicate key" (parse-string duplicate-keys-yaml :allow-duplicate-keys false))))


### PR DESCRIPTION
This exposes the `setAllowDuplicateKeys` loader option to parse-string via `allow-duplicate-keys`