### PR TITLE
Support namespaced keys

### DIFF
--- a/src/clojure/clj_yaml/core.clj
+++ b/src/clojure/clj_yaml/core.clj
@@ -114,7 +114,8 @@
 
   clojure.lang.Keyword
   (encode [data]
-    (name data))
+    ;; using clojure.core/name would drop the namespace
+    (subs (str data) 1))
 
   java.util.LinkedHashMap
   (decode [data keywords]

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -227,6 +227,17 @@ a: 1
 a: 1
 ")
 
-(deftest allow-recursive-works
+(deftest duplicate-keys-works
   (is (parse-string duplicate-keys-yaml))
   (is (thrown-with-msg? DuplicateKeyException #"found duplicate key" (parse-string duplicate-keys-yaml :allow-duplicate-keys false))))
+
+(def namespaced-keys-yaml "
+foo/bar: 42
+")
+
+(deftest namespaced-keys-works
+  (testing "namespaced keys in yaml can round trip through parse and generate"
+    (is (= {:foo/bar 42} (-> namespaced-keys-yaml
+                             parse-string
+                             generate-string
+                             parse-string)))))


### PR DESCRIPTION
Namespaced keys are already supported by `parse-string` but `generate-string`, which uses [`clojure.core/name`](https://clojuredocs.org/clojure.core/name), strips the namespace away. 

This PR fixes #16 by trimming the leadin `:` symbol out of the `str` representation of the keyword, which retains its namespace if present