### PR TITLE
Creating a vector from an array list instead of a seq

### DIFF
--- a/src/clojure/clj_yaml/core.clj
+++ b/src/clojure/clj_yaml/core.clj
@@ -63,7 +63,7 @@
     (Yaml. constructor (Representer.) dumper loader)))
 
 (defrecord Marked
-  [start end unmark])
+           [start end unmark])
 
 (defn mark
   "Mark some data with start and end positions."
@@ -133,7 +133,7 @@
 
   java.util.ArrayList
   (decode [data keywords]
-    (map #(decode % keywords) data))
+    (mapv #(decode % keywords) data))
 
   Object
   (encode [data] data)
@@ -142,7 +142,6 @@
   nil
   (encode [data] data)
   (decode [data keywords] data))
-
 
 (defn generate-string [data & opts]
   (.dump ^Yaml (apply make-yaml opts)

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -84,6 +84,9 @@ the-bin: !!binary 0101")
     (is (= "North by Northwest"       (nth parsed 1)))
     (is (= "The Man Who Wasn't There" (nth parsed 2)))))
 
+(deftest parsed-list-is-a-vector
+  (is (vector? (parse-string list-yaml))))
+
 (deftest parse-nested-hash-and-list
   (let [parsed (parse-string hashes-lists-yaml)]
     (is (= "A4786"  ((first (parsed :items)) :part_no)))


### PR DESCRIPTION
A small change that fixes the way java.util.ArrayList is handled, right now when you parse a yml string that has an array you get back a seq, this break the expected contract since you can't access items within that array using an index for example:

```yaml
services:
  wazuh-master:
    image: wazuh/wazuh-odfe:4.0.4_1.11.0
    hostname: wazuh-master
    restart: always
    ports:
      - "1515:1515"
      - "514:514/udp"
      - "55000:55000"
    environment:
      - ELASTICSEARCH_URL=https://elasticsearch:9200
      - ELASTIC_USERNAME=admin
      - ELASTIC_PASSWORD=...
      - FILEBEAT_SSL_VERIFICATION_MODE=full
      - SSL_CERTIFICATE_AUTHORITIES=/etc/ssl/root-ca.pem
      - SSL_CERTIFICATE=/etc/ssl/filebeat.pem
      - SSL_KEY=/etc/ssl/filebeat.key
      - API_USERNAME=acme-user```
```      
     
The environment variables are parsed as a seq, this breaks the expected contract with the yml input (which is an array):
      
  ```clojure
> (get-in (yaml/parse-string (slurp "docker-compose.yml") :mark false) [:services :wazuh-master :environment] )

("ELASTICSEARCH_URL=https://elasticsearch:9200"
 "ELASTIC_USERNAME=admin"
 "ELASTIC_PASSWORD=SecretPassword"
 "FILEBEAT_SSL_VERIFICATION_MODE=full"
 "SSL_CERTIFICATE_AUTHORITIES=/etc/ssl/root-ca.pem"
 "SSL_CERTIFICATE=/etc/ssl/filebeat.pem"
 "SSL_KEY=/etc/ssl/filebeat.key"
 "API_USERNAME=acme-user")
 ``` 
 
 After this fix the result will be:

```clojure
> (get-in (yaml/parse-string (slurp "docker-compose.yml") :mark false) [:services :wazuh-worker :environment] )

["ELASTICSEARCH_URL=https://elasticsearch:9200"
 "ELASTIC_USERNAME=admin"
 "ELASTIC_PASSWORD=..."
 "FILEBEAT_SSL_VERIFICATION_MODE=full"
 "SSL_CERTIFICATE_AUTHORITIES=/etc/ssl/root-ca.pem"
 "SSL_CERTIFICATE=/etc/ssl/filebeat.pem"
 "SSL_KEY=/etc/ssl/filebeat.key"]
```

Thanks