### PR TITLE
Add support for indent and indicator-indent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ classes
 pom.xml*
 /target
 /.lein-failures
+/.lsp
+/.clj-kondo
+.nrepl-port
+/.calva

--- a/README.md
+++ b/README.md
@@ -52,17 +52,19 @@ Use the `:indent` (default: 2) and `:indicator-indent` (default: 0) options to a
 
 ```clojure
 (yaml/generate-string some-data :dumper-options {:indent 6
-                                                 :indicator-indend 3})
+                                                 :indicator-indent 3
+                                                 :flow-style :block})
 =>
 todo:
-   -    name: Fix issue
-        responsible:
-                name: Rita
+   -  name: Fix issue
+      responsible:
+            name: Rita
 ```
 `:indent` must always be larger than `:indicator-indent`. If only 1 higher, the indicator will be on a separate line:
 ```clojure
 (yaml/generate-string some-data :dumper-options {:indent 2
-                                                 :indicator-indend 1})
+                                                 :indicator-indent 1
+                                                 :flow-style :block})
 =>
 todo:
  -

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Different flow styles (`:auto`, `:block`, `:flow`) allow customization of how YA
 (yaml/generate-string some-data :dumper-options {:flow-style :block})
 ```
 
-Use the :indent (default: 2) and :indicator-indent (default: 0) options to adjust indentation:
+Use the `:indent` (default: 2) and `:indicator-indent` (default: 0) options to adjust indentation:
 
 ```clojure
 (yaml/generate-string some-data :dumper-options {:indent 6
@@ -59,7 +59,7 @@ todo:
         responsible:
                 name: Rita
 ```
-:indent must always be larger than :indicator-indent. If only 1 higher, the indicator will be on a separate line:
+`:indent` must always be larger than `:indicator-indent`. If only 1 higher, the indicator will be on a separate line:
 ```clojure
 (yaml/generate-string some-data :dumper-options {:indent 2
                                                  :indicator-indend 1})

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ Different flow styles (`:auto`, `:block`, `:flow`) allow customization of how YA
 (yaml/generate-string some-data :dumper-options {:flow-style :block})
 ```
 
+Use the :indent (default: 2) and :indicator-indent (default: 0) options to adjust indentation:
+
+```clojure
+(yaml/generate-string some-data :dumper-options {:indent 6
+                                                 :indicator-indend 3})
+=>
+todo:
+   -    name: Fix issue
+        responsible:
+                name: Rita
+```
+:indent must always be larger than :indicator-indent. If only 1 higher, the indicator will be on a separate line:
+```clojure
+(yaml/generate-string some-data :dumper-options {:indent 2
+                                                 :indicator-indend 1})
+=>
+todo:
+ -
+  name: Fix issue
+  responsible:
+    name: Rita
+```
+
 ## Installation
 
 `clj-commons/clj-yaml` is available as a Maven artifact from [Clojars](http://clojars.org/clj-commons/clj-yaml).

--- a/src/clojure/clj_yaml/core.clj
+++ b/src/clojure/clj_yaml/core.clj
@@ -23,9 +23,15 @@
     (.setSplitLines false)))
 
 (defn ^DumperOptions make-dumper-options
-  [& {:keys [flow-style]}]
-  (doto (default-dumper-options)
-    (.setDefaultFlowStyle (flow-styles flow-style))))
+  [{:keys [flow-style indent indicator-indent]}]
+  (let [dumper (default-dumper-options)]
+    (when flow-style
+      (.setDefaultFlowStyle dumper (flow-styles flow-style)))
+    (when indent
+      (.setIndent dumper indent))
+    (when indicator-indent
+      (.setIndicatorIndent dumper indicator-indent))
+    dumper))
 
 (defn ^LoaderOptions default-loader-options
   []
@@ -57,9 +63,7 @@
               (MarkedConstructor.)
               (SafeConstructor. loader)))
         ;; TODO: unsafe marked constructor
-        dumper (if dumper-options
-                 (make-dumper-options :flow-style (:flow-style dumper-options))
-                 (default-dumper-options))]
+        dumper (make-dumper-options dumper-options)]
     (Yaml. constructor (Representer.) dumper loader)))
 
 (defrecord Marked

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -33,7 +33,7 @@ items:
 ")
 
 (def inline-list-yaml
-"--- # Shopping list
+  "--- # Shopping list
 [milk, pumpkin pie, eggs, juice]
 ")
 
@@ -166,8 +166,8 @@ the-bin: !!binary 0101")
       ;; This test ensures that generate-string uses the older behavior by default, for the sake
       ;; of stability, i.e. backwards compatibility.
       (is
-        (= "{description: Big-picture diagram showing how our top-level systems and stakeholders interact}\n"
-           (generate-string data))))))
+       (= "{description: Big-picture diagram showing how our top-level systems and stakeholders interact}\n"
+          (generate-string data))))))
 
 (deftest dump-opts
   (let [data [{:age 33 :name "jon"} {:age 44 :name "boo"}]]
@@ -186,7 +186,7 @@ the-bin: !!binary 0101")
   (let [parsed (parse-string hashes-lists-yaml)
         [first second] (:items parsed)]
     (is (= (keys first) '(:part_no :descrip :price :quantity)))
-    (is (= (keys second)'(:part_no :descrip :price :quantity :owners)))))
+    (is (= (keys second) '(:part_no :descrip :price :quantity :owners)))))
 
 
 (deftest nulls-are-fine
@@ -276,3 +276,18 @@ foo/bar: 42
     (is (roundtrip list-yaml))
     (is (roundtrip nested-hash-yaml))))
 
+(def indented-yaml "todo:
+  -  name: Fix issue
+     responsible:
+          name: Rita
+")
+
+(deftest indentation-test
+  (testing "Can use indicator-indent and indent to achieve desired indentation"
+    (is (not= indented-yaml (generate-string (parse-string indented-yaml)
+                                             :dumper-options {:flow-style :block})))
+    (is (= indented-yaml
+           (generate-string (parse-string indented-yaml)
+                            :dumper-options {:indent 5
+                                             :indicator-indent 2
+                                             :flow-style :block})))))


### PR DESCRIPTION
This change makes it possible to specify the desired
indentation both for the sequence-indicator and for
nested keys.