### PR TITLE
Bump snakeyaml to 1.31. Fixes CVE-2022-25857

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,6 @@
   :java-source-paths ["src/java"]
   :javac-options ["-target" "1.7" "-source" "1.7" "-Xlint:-options"]
   :dependencies
-  [[org.yaml/snakeyaml "1.26"]
+  [[org.yaml/snakeyaml "1.31"]
    [org.flatland/ordered "1.5.9"]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.1"]]}})


### PR DESCRIPTION
This project depends on `[org.yaml/snakeyaml "1.26"]` 

This version of snakeyaml suffers from [CVE-2022-25857](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-25857):

> The package org.yaml:snakeyaml from 0 and before 1.31 are vulnerable to Denial of Service (DoS) due missing to nested depth limitation for collections.

This PR simply bumps snakeyaml to the latest version (where this is no CVE). 
The unit tests still pass, and from what I can tell there should be no breaking changes.