### PR TITLE
Upgrade snakeyaml to 1.32

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,6 @@
   :java-source-paths ["src/java"]
   :javac-options ["-target" "1.7" "-source" "1.7" "-Xlint:-options"]
   :dependencies
-  [[org.yaml/snakeyaml "1.31"]
+  [[org.yaml/snakeyaml "1.32"]
    [org.flatland/ordered "1.5.9"]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.1"]]}})


### PR DESCRIPTION
~Fixes CVE-2022-38752~ Doesn't seem to fix that CVE (at least not according to CVE tracking sites), but probably still worth upgrading.