### PR TITLE
Add tools.build + deps/prep-lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml*
 /.clj-kondo
 .nrepl-port
 /.calva
+.cpcache

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,30 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]))
+
+(def lib 'clj-commons/clj-yaml)
+(def version (System/getenv "PROJECT_VERSION"))
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn compile-java [_]
+  (b/javac {:src-dirs ["src/java"]
+            :class-dir class-dir
+            :basis basis
+            :javac-opts ["-source" "8" "-target" "8"]}))
+
+(defn jar [_]
+  (compile-java nil)
+  (b/write-pom {:class-dir class-dir
+                :lib lib
+                :version version
+                :basis basis
+                :src-dirs ["src/clojure"]})
+  (b/copy-dir {:src-dirs ["src/clojure"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file jar-file}))
+

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,11 @@
+{:paths ["src/clojure" "target/classes"]
+ :deps {org.yaml/snakeyaml {:mvn/version "1.32"}
+        org.flatland/ordered {:mvn/version "1.5.9"}}
+ :deps/prep-lib {:alias :build
+                 :fn compile-java
+                 :ensure "target/classes"}
+ :aliases
+ {:build ;; added by neil
+  {:deps {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}
+          slipset/deps-deploy {:mvn/version "0.2.0"}}
+   :ns-default build}}}


### PR DESCRIPTION
This allows the library to be used as a git dependency, given that you prepare it:

```
borkdude@m1 /tmp/test-yaml $ cat deps.edn
{:deps {clj-commons/clj-yaml {:git/url "https://github.com/clj-commons/clj-yaml"
                              :git/sha "b7b0ebf92f0aed3cfc545303af6988c08455519a"}}}
borkdude@m1 /tmp/test-yaml $ clj -X:deps prep

borkdude@m1 /tmp/test-yaml $ clj -M -e "(require '[clj-yaml.core :as yaml]) (doseq [x [\"083\" {:x \"083\"}]] (print (yaml/generate-string x)))"
083
{x: 083}
```