### PR TITLE
Test against all supported versions of Clojure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,4 +47,4 @@ jobs:
       run: bb compile-java
 
     - name: Run tests
-      run: bb test
+      run: bb test --clj-version :all

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,7 +18,7 @@ Clj-yaml makes use of SnakeYAML, please also refer to the https://bitbucket.org/
 With this release we move to a `1.x.<release count>` scheme.
 
 * Docs
-** Docs and docstring reviewed and updated 
+** Docs and docstring reviewed and updated
 (https://github.com/clj-commons/clj-yaml/issues/65[#65])
 (https://github.com/lead[@lread])
 ** Public API reviewed and defined and documented
@@ -30,6 +30,9 @@ With this release we move to a `1.x.<release count>` scheme.
 (https://github.com/lread[@lread])
 ** Expanded automatic CI testing to include JDKs 11, 17 and Windows (was previously JDK8 and Ubuntu only)
 (https://github.com/clj-commons/clj-yaml/issues/47[#47])
+(https://github.com/lead[@lread])
+** Now CI testing against all supported Clojure versions (was previously just testing against default on CI)
+(https://github.com/clj-commons/clj-yaml/issues/71[#71])
 (https://github.com/lead[@lread])
 ** Added more automation when publishing a release
 (https://github.com/clj-commons/clj-yaml/issues/47[#47])
@@ -48,7 +51,7 @@ See https://github.com/clj-commons/clj-yaml/issues/67[#67].
 
 * Support loading all YAML docs via new `:load-all` opt for `parse-string` and `parse-stream`
 (https://github.com/clj-commons/clj-yaml/pull/22[#22])
-(https://github.com/clj-commons/clj-yaml/commits?author=clumsyjedi[@clumsyjedi])
+(https://github.com/clumsyjedi[@clumsyjedi])
 
 *  Support `:unknown-tag-fn` to read unknown tags and values
 (https://github.com/clj-commons/clj-yaml/issues/23[#23])

--- a/bb.edn
+++ b/bb.edn
@@ -23,11 +23,8 @@
          {:doc "compile java sources"
           :task (clojure "-T:build compile-java")}
          test
-         {:doc "run tests (recognizes cognitect test-runner args)"
-          :task (do
-                  (when (not (fs/exists? "target/classes"))
-                    (run 'compile-java))
-                  (apply clojure "-M:test" *command-line-args*))}
+         {:doc "Runs tests under Clojure [--clj-version] (recognizes cognitect test-runner args)"
+          :task test-clj/-main}
          lint
          {:doc "[--rebuild] Lint source code"
           :task lint/-main}

--- a/deps.edn
+++ b/deps.edn
@@ -9,6 +9,10 @@
   ;; publish workflow references these values (and automatically bumps patch)
   :neil {:project {:version "1.0.25"
                    :name clj-commons/clj-yaml}}
+  :1.8 {:override-deps {org.clojure/clojure {:mvn/version "1.8.0"}}}
+  :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
+  :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
+  :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}}
   :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -86,6 +86,14 @@ You can also include cognitect test runner options:
 $ bb test --var 'clj-yaml.core-test/emoji-can-be-parsed'
 ----
 
+...and/or Clojure version:
+
+[source,shell]
+----
+$ bb test --clj-version 1.9
+----
+(defaults to `1.8`, specify `:all` to test against all supported Clojure versions)
+
 Our CI workflow lints sources with clj-kondo, and you can too!
 
 [source,shell]

--- a/script/test_clj.clj
+++ b/script/test_clj.clj
@@ -1,0 +1,46 @@
+(ns test-clj
+  (:require [babashka.cli :as cli]
+            [babashka.tasks :as t]
+            [lread.status-line :as status]))
+
+(defn -main [& args]
+  (let [all-clojure-versions ["1.8" "1.9" "1.10" "1.11"]
+        valid-clj-version-opt-values (conj all-clojure-versions ":all")
+        spec {:clj-version
+              {:ref "<version>"
+               :desc "The Clojure version to test against."
+               :coerce :string
+               :default-desc "1.8"
+               ;; don't specify :default, we want to know if the user passed this option in
+               :validate
+               {:pred (set valid-clj-version-opt-values)
+                :ex-msg (fn [_m]
+                          (str "--clj-version must be one of: " valid-clj-version-opt-values))}}}
+        opts (cli/parse-opts args {:spec spec})
+        clj-version (:clj-version opts)
+        runner-args (if-not clj-version
+                      args
+                      (loop [args args
+                             out-args []]
+                        (if-let [a (first args)]
+                          (if (re-matches #"(--|:)clj-version" a)
+                            (recur (drop 2 args) out-args)
+                            (recur (rest args) (conj out-args a)))
+                          out-args)))
+        clj-version (or clj-version "1.8")]
+
+    (if (:help opts)
+      (do
+        (status/line :head "bb task option help")
+        (println (cli/format-opts {:spec spec}))
+        (status/line :head "test-runner option help")
+        (t/clojure "-M:test --test-help"))
+      (let [clj-versions (if (= ":all" clj-version)
+                           all-clojure-versions
+                           [clj-version])]
+        (doseq [v clj-versions]
+          (status/line :head "Testing against Clojure version %s" v)
+          (apply t/clojure (format "-M:%s:test" v) runner-args))))))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clj-yaml.core :as yaml :refer [generate-stream generate-string
                                    parse-stream parse-string unmark]]
+   [clj-yaml.test-report]
    [clojure.java.io :as io]
    [clojure.string :as string]
    [clojure.test :refer (deftest testing is)]

--- a/test/clj_yaml/test_report.clj
+++ b/test/clj_yaml/test_report.clj
@@ -1,0 +1,9 @@
+(ns clj-yaml.test-report
+  (:require [clojure.test]))
+
+(def platform
+  (str "jvm-clj " (clojure-version)))
+
+(defmethod clojure.test/report :begin-test-var [m]
+  (let [test-name (-> m :var meta :name)]
+    (println (format "=== %s [%s]" test-name platform))))


### PR DESCRIPTION
Task `bb test` adds `--clj-version` option which can be 1.8, 1.9, 1.10, 1.11 or :all.
Defaults to 1.8

CI adjusted to use `bb test --clj-version :all`.

Includes test reporter that shows test name with clj version.

Closes #71