### PR TITLE
Unbreak YAMLCodec's decode

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,10 +13,17 @@ Clj-yaml makes use of SnakeYAML, please also refer to the https://bitbucket.org/
 // - unreleased section empty
 // - optional attribute is not [breaking] or [minor breaking]
 //   (adjust these in publish.clj as you see fit)
-== Unreleased
+== Unreleased [minor breaking]
 
-With this release we move to a `1.x.<release count>` scheme.
+WARNING: We addressed the breaking change in 0.7.169.
+This breaks v0.7.169 for those directly using the low-level `decode` function, but restores compatibility for prior versions.
 
+* Breaking changes
+** Unbreak breaking change introduced in v0.7.169 and break v0.7.169 for low level `decode` function
+(https://github.com/clj-commons/clj-yaml/issues/67[#67])
+(https://github.com/lead[@lread])
+
+* With this release we move to a `1.x.<release count>` scheme.
 * Docs
 ** Docs and docstring reviewed and updated
 (https://github.com/clj-commons/clj-yaml/issues/65[#65])

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -109,6 +109,26 @@ Depending on the YAML you are parsing, you very well might want to set this to `
 When clj-yaml detects a key that cannot be converted to a Clojure keyword, it will leave it unconverted.
 Keep in mind detection is not sophisticated and can result in keywords that are illegal and unreadable.
 
+[[keyword-args]]
+==== Function Options as Keyword Args
+
+You'll notice that clj-yaml functions use keyword args for options.
+
+Clojure 1.11 allows these types of functions to instead be called with a map for the options:
+
+[source,clojure]
+----
+;; old school
+(yaml/parse-string "ok: 42" :keywords false)
+;; => {"ok" 42}
+
+;; clojure 1.11 also allows:
+(yaml/parse-string "ok: 42" {:keywords false})
+;; => {"ok" 42}
+----
+
+TIP: If you are using a version of Clojure before v1.11, or you want to stay compatible with older versions of Clojure, you'll need to call these functions the old school way.
+
 ==== Unknown tags [[unknown-tags]]
 Unknown tags can be handled by passing a handler function via the `:unknown-tag-fn` option.
 The handler function is provided a map which includes `:tag` and `:value` keys.

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -394,3 +394,30 @@ sequence: !CustomSequence
   (let [parsed (parse-string "!!java.lang.Long 5" :unsafe true)]
     (is (= 5 parsed) "SnakeYAML can be asked to create innocuous looking classes - value match")
     (is (= "class java.lang.Long" (str (class parsed))) "SnakeYAML can be asked to create innocuous looking classes - type match")))
+
+(deftest low-level-decode-legacy-compat-test
+  ;; Dear reader, we don't want to encourage you to use low level functions in this way,
+  ;; this test is here to verify that we are compatible with existing code in the wild
+  (let [to-decode (doto (java.util.LinkedHashMap.) (.put "a" 1))]
+    (is (= (ordered-map {"a" 1})
+           (yaml/decode to-decode false))
+        "decode supports legacy [data keywords] signature - keywords false")
+    (is (= (ordered-map {:a 1})
+           (yaml/decode to-decode true))
+        "decode supports legacy [data keywords] signature - keywords true")
+
+    (is (= (ordered-map {"a" 1})
+           (yaml/decode to-decode nil))
+        "decode supports legacy [data keywords] signature - keywords nil")
+
+    (is (= (ordered-map {"a" 1})
+           (yaml/decode to-decode {}))
+        "decode supports new [data opts] signature - keywords not specified")
+
+    (is (= (ordered-map {:a 1})
+           (yaml/decode to-decode {:keywords true}))
+        "decode supports new [data opts] signature - keywords specified true")
+
+    (is (= (ordered-map {"a" 1})
+           (yaml/decode to-decode {:keywords false}))
+        "decode supports new [data opts] signature - keywords specified true")))

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -396,7 +396,7 @@ sequence: !CustomSequence
     (is (= "class java.lang.Long" (str (class parsed))) "SnakeYAML can be asked to create innocuous looking classes - type match")))
 
 (deftest low-level-decode-legacy-compat-test
-  ;; Dear reader, we don't want to encourage you to use low level functions in this way,
+  ;; Dear reader, we don't want to encourage you to use low level functions in any way,
   ;; this test is here to verify that we are compatible with existing code in the wild
   (let [to-decode (doto (java.util.LinkedHashMap.) (.put "a" 1))]
     (is (= (ordered-map {"a" 1})


### PR DESCRIPTION
Version 0.7.169 of clj-yaml changed YAMLCodec's decode function signature. We assumed this was an internal-only function but have since learned that this is sometimes used in the wild.

This change breaks 0.7.169 but unbreaks prior versions.

- old sig: (decode [data keywords])
- 0.7.169: (decode [data keywords unknown-tag-fn])
- new sig: (decode [data opts])

We interpret opts as an options map, if it is not of type map we assume legacy support for old sig and interpret it as keywords boolean.

Also:
- added a note to user guide about clj-yaml's keyword args fns
- made high level api fn signatures that use keyword args consistent

Closes #67