### PR TITLE
Add :key-fn for control of YAML key conversion

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,12 +17,16 @@ Clj-yaml makes use of SnakeYAML, please also refer to the https://bitbucket.org/
 
 WARNING: We addressed the breaking change in 0.7.169.
 This breaks v0.7.169 for those directly using the low-level `decode` function, but restores compatibility for prior versions.
+Those not using the low-level `decode` function directly are unaffected.
 
 * Breaking changes
 ** Unbreak breaking change introduced in v0.7.169 and break v0.7.169 for low level `decode` function
 (https://github.com/clj-commons/clj-yaml/issues/67[#67])
 (https://github.com/lead[@lread])
-
+* New Features
+** Added `:key-fn` to `parse-string` and `parse-stream` for full control over YAML key conversion
+(https://github.com/clj-commons/clj-yaml/issues/64[#64])
+(https://github.com/lead[@lread])
 * With this release we move to a `1.x.<release count>` scheme.
 * Docs
 ** Docs and docstring reviewed and updated

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -135,25 +135,6 @@ Or, something entirely different:
 ;; => ({"EMAN" "John Smith"})
 ----
 
-[[keyword-args]]
-==== Function Options as Keyword Args
-
-You'll notice that clj-yaml functions use keyword args for options.
-
-Clojure 1.11 allows these types of functions to instead be called with a map for the options:
-
-[source,clojure]
-----
-;; old school
-(yaml/parse-string "ok: 42" :keywords false)
-;; => {"ok" 42}
-
-;; clojure 1.11 also allows:
-(yaml/parse-string "ok: 42" {:keywords false})
-;; => {"ok" 42}
-----
-
-TIP: If you are using a version of Clojure before v1.11, or you want to stay compatible with older versions of Clojure, you'll need to call these functions the old school way.
 
 ==== Unknown tags [[unknown-tags]]
 Unknown tags can be handled by passing a handler function via the `:unknown-tag-fn` option.
@@ -307,3 +288,23 @@ todo:
   responsible:
     name: Rita
 ----
+
+[[keyword-args]]
+=== Function Options as Keyword Args
+
+You'll notice that clj-yaml functions use keyword args for options.
+
+Clojure 1.11 allows these types of functions to instead be called with a map for the options:
+
+[source,clojure]
+----
+;; old school
+(yaml/parse-string "ok: 42" :keywords false)
+;; => {"ok" 42}
+
+;; clojure 1.11 also allows:
+(yaml/parse-string "ok: 42" {:keywords false})
+;; => {"ok" 42}
+----
+
+TIP: If you are using a version of Clojure before v1.11, or you want to stay compatible with older versions of Clojure, you'll need to call these functions the old school way.

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -93,8 +93,10 @@ Note that:
 
 === Parsing YAML
 
+[[key-conv]]
 ==== Key Conversion
-By default, YAML keys are converted to Clojure keywords. To prevent this, add the `:keywords false` option to the `parse-string` function:
+
+By default, YAML keys are converted to Clojure keywords. To prevent this, include the `:keywords false` option when calling `parse-string` or `parse-stream` functions:
 
 [source,clojure]
 ----
@@ -104,10 +106,34 @@ By default, YAML keys are converted to Clojure keywords. To prevent this, add th
 ;; => ({"name" "John Smith"})
 ----
 
-TIP: The `:keywords` option defaults to `true` for historical reasons.
-Depending on the YAML you are parsing, you very well might want to set this to `false`.
+The `:keywords` option defaults to `true` for historical reasons.
 When clj-yaml detects a key that cannot be converted to a Clojure keyword, it will leave it unconverted.
-Keep in mind detection is not sophisticated and can result in keywords that are illegal and unreadable.
+Detection and conversion is not sophisticated and can result in keywords that are illegal and unreadable.
+
+For this reason we added the `:key-fn` option.
+This allows you to take control and do whatever conversion makes sense for your YAML key inputs.
+
+You can use `:key-fn` to do something similar to `:keywords true`:
+
+[source,clojure]
+----
+(yaml/parse-string "
+- {name: John Smith}
+" :key-fn #(-> % :key keyword))
+;; => ({:name "John Smith"})
+----
+
+Or, something entirely different:
+
+[source,clojure]
+----
+(require '[clojure.string :as string])
+
+(yaml/parse-string "
+- {name: John Smith}
+" :key-fn #(-> % :key string/upper-case string/reverse))
+;; => ({"EMAN" "John Smith"})
+----
 
 [[keyword-args]]
 ==== Function Options as Keyword Args

--- a/src/clojure/clj_yaml/core.clj
+++ b/src/clojure/clj_yaml/core.clj
@@ -265,7 +265,7 @@
 
   Valid `& opts` (`opts` are keyword args, see [docs](/doc/01-user-guide.adoc#keyword-args)):
   - `:key-fn` - Single-argument fn, arg is a map with `:key`; called on YAML keys, return replaces YAML key.
-    - default behaviour: no key conversion
+    - default behaviour: see `:keywords`
     - overrides `:keywords`, consider using this option instead of `:keywords`
     - see [docs](/doc/01-user-guide.adoc#key-conv)
   - `:keywords` - when `true` attempts to convert YAML keys to Clojure keywords, else makes no conversion

--- a/src/clojure/clj_yaml/core.clj
+++ b/src/clojure/clj_yaml/core.clj
@@ -208,12 +208,12 @@
 
   java.util.LinkedHashMap
   (decode [data opts]
-    (let [{:keys [keywords] :as opts} (decode-opts opts)]
+    (let [{:keys [keywords key-fn] :as opts} (decode-opts opts)]
       (letfn [(decode-key [k]
-                (if keywords
-                  ;; (keyword k) is nil for numbers etc
-                  (or (keyword k) k)
-                  k))]
+                (cond
+                  key-fn (key-fn {:key k})
+                  keywords (or (keyword k) k)
+                  :else k))]
         (into (ordered-map)
               (for [[k v] data]
                 [(-> k (decode opts) decode-key) (decode v opts)])))))
@@ -264,10 +264,17 @@
   "Returns parsed `yaml-string` as Clojure data structures.
 
   Valid `& opts` (`opts` are keyword args, see [docs](/doc/01-user-guide.adoc#keyword-args)):
+  - `:key-fn` - Single-argument fn, arg is a map with `:key`; called on YAML keys, return replaces YAML key.
+    - default behaviour: no key conversion
+    - overrides `:keywords`, consider using this option instead of `:keywords`
+    - see [docs](/doc/01-user-guide.adoc#key-conv)
   - `:keywords` - when `true` attempts to convert YAML keys to Clojure keywords, else makes no conversion
     - default: `true`.
+    - ignored when `:key-fn` is specified
     - when clj-yaml detects that a YAML key cannot be converted to a legal Clojure keyword it leaves the key as is.
     - detection is not sophisticated and clj-yaml will produce invalid Clojure keywords, so although our default is `true` here, `false` can be a better choice.
+    - consider instead using `:key-fn`
+    - see [docs](/doc/01-user-guide.adoc#key-conv)
   - `:load-all` - when `true` loads all YAML documents from `yaml-string` and returns a vector of parsed docs.
   Else only first YAML document is loaded, and return is that individual parsed doc.
     - default: `false`
@@ -286,7 +293,7 @@
     - **WARNING**: be very wary of parsing unsafe YAML. See [docs](/doc/01-user-guide.adoc#unsafe)
   - `:mark` - when `true` position of YAML input is tracked and returned in alternate structure.
     - default: `false`
-    - See [docs](/doc/01-user-guide.adoc#mark)
+    - see [docs](/doc/01-user-guide.adoc#mark)
 
   Note: clj-yaml will only recognize the first of `:unsafe`, `:mark` or `:unknown-tag-fn`"
   [^String yaml-string & opts]

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -150,6 +150,34 @@ the-bin: !!binary 0101")
                   first
                   keys))))
 
+(deftest unconvertable-key-not-converted-to-keyword
+  ;; we are not sophisticated here, but do handle some cases
+  (is (= {42 1 :b 2}
+         (parse-string "{42: 1, b: 2}" :keywords true))))
+
+(deftest key-fn-option
+  (is (= {:a 1}
+         (parse-string "{a: 1}" :key-fn #(-> % :key keyword)))
+      "can operate like :keywords true")
+  (is (= {"A" 1}
+         (parse-string "{a: 1}" :key-fn #(-> % :key string/upper-case)))
+      "overrides default :keywords true")
+  (is (= {"A" 1}
+         (parse-string "{a: 1}"
+                       :keywords false
+                       :key-fn #(-> % :key string/upper-case)))
+      "overrides :keywords false")
+  (is (= {"A" 1}
+         (parse-string "{a: 1}"
+                       :keywords true
+                       :key-fn #(-> % :key string/upper-case)))
+      "overrides :keywords true")
+  (is (= {"BA" 1}
+         (parse-string "{!blam ab: 1}"
+                       :key-fn #(-> % :key string/upper-case)
+                       :unknown-tag-fn #(-> % :value string/reverse)))
+      "can be combined with :unknown-tag-fn"))
+
 (deftest marking-source-position-works
   (let [parsed (parse-string inline-list-yaml :mark true)]
     ;; The list starts at the beginning of line 1.


### PR DESCRIPTION
The parse-string and parse-stream function now accept new :key-fn
option.
    
See docs and docstrings for details.
    
Closes #64