### PR TITLE
linting: bump kondo, add eastwood

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,2 +1,5 @@
 ;; don't adopt any user preferences
-{:config-paths ^:replace []}
+{:config-paths ^:replace []
+ :linters {:redundant-fn-wrapper {:level :warning}
+           :unused-value {:level :warning}
+           :aliased-namespace-symbol {:level :warning}}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  lint:
+  lint-kondo:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +21,22 @@ jobs:
           jdk: '11'
 
       - name: Lint
-        run: bb lint
+        run: bb lint-kondo
+
+  lint-eastwood:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Setup
+        uses: ./.github/workflows/shared-setup
+        with:
+          jdk: '11'
+
+      - name: Lint
+        run: bb lint-eastwood
 
   test:
     runs-on: ${{ matrix.os.name }}-latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ classes
 .nrepl-port
 /.calva
 .cpcache
+/.eastwood

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,14 @@ Clj-yaml makes use of SnakeYAML, please also refer to the https://bitbucket.org/
 //   (adjust these in publish.clj as you see fit)
 == Unreleased
 
+* Quality
+** Stop using deprecated SnakeYAML Representer constructor
+(https://github.com/clj-commons/clj-yaml/issues/76[#76])
+(https://github.com/lead[@lread])
+** Add Eastwood linting as lint-eastwood bb task and to CI
+(https://github.com/clj-commons/clj-yaml/issues/77[#77])
+(https://github.com/lead[@lread])
+
 == v1.0.26 [minor breaking] - 2022-10-04 [[v1.0.26]]
 
 WARNING: We addressed the breaking change in 0.7.169.
@@ -38,7 +46,7 @@ Those not using the low-level `decode` function directly are unaffected.
 (https://github.com/clj-commons/clj-yaml/issues/66[#66])
 (https://github.com/lead[@lread])
 * Quality
-** Stop using deprecated SnakeYAML constructor
+** Stop using deprecated SnakeYAML SafeConstructor constructor
 (https://github.com/clj-commons/clj-yaml/issues/61[#61])
 (https://github.com/lread[@lread])
 ** Expanded automatic CI testing to include JDKs 11, 17 and Windows (was previously JDK8 and Ubuntu only)

--- a/bb.edn
+++ b/bb.edn
@@ -25,9 +25,16 @@
          test
          {:doc "Runs tests under Clojure [--clj-version] (recognizes cognitect test-runner args)"
           :task test-clj/-main}
-         lint
-         {:doc "[--rebuild] Lint source code"
+         lint-kondo
+         {:doc "[--rebuild] Lint source code with clj-kondo"
           :task lint/-main}
+         lint-eastwood
+         {:doc "Lint source code with Eastwood"
+          :depends [compile-java]
+          :task (clojure "-M:test:eastwood")}
+         lint
+         {:doc "Run all lints"
+          :depends [lint-kondo lint-eastwood]}
          pubcheck
          {:doc "run only publish checks (without publishing)"
           :task publish/pubcheck}

--- a/bb.edn
+++ b/bb.edn
@@ -24,7 +24,11 @@
           :task (clojure "-T:build compile-java")}
          test
          {:doc "Runs tests under Clojure [--clj-version] (recognizes cognitect test-runner args)"
-          :task test-clj/-main}
+          :requires ([test-clj])
+          :task (do
+                  (when (not (fs/exists? "target/classes"))
+                    (run 'compile-java))
+                  (apply test-clj/-main *command-line-args*))}
          lint-kondo
          {:doc "[--rebuild] Lint source code with clj-kondo"
           :task lint/-main}

--- a/build.clj
+++ b/build.clj
@@ -32,13 +32,15 @@
     (println "compile-java with java version" version)
     (when (< major 8)
       (throw (ex-info "jdk version must be at least 8" {})))
-    (b/javac (cond-> {:src-dirs ["src/java"]
-                      :class-dir class-dir
-                      :basis basis
-                      :javac-opts ["-Xlint"]}
-               (> major 8)
-               ;; replaces old jdk <= 8 -source and -target opts
-               (assoc :javac-opts ["--release" "8" "-Xlint" "-Werror"])))))
+    (let [javac-opts ["-Xlint" "-Werror"]]
+      (b/javac (cond-> {:src-dirs ["src/java"]
+                        :class-dir class-dir
+                        :basis basis
+                        ;; don't need -source and -target because by default we are compiling with jdk8
+                        :javac-opts javac-opts}
+                 (> major 8)
+                 ;; --release replaces -source and -target opts for > jdk8
+                 (update :javac-opts #(conj % "--release" "8")))))))
 
 (defn jar [_]
   (compile-java nil)

--- a/build.clj
+++ b/build.clj
@@ -38,7 +38,7 @@
                       :javac-opts ["-Xlint"]}
                (> major 8)
                ;; replaces old jdk <= 8 -source and -target opts
-               (assoc :javac-opts ["--release" "8" "-Xlint"])))))
+               (assoc :javac-opts ["--release" "8" "-Xlint" "-Werror"])))))
 
 (defn jar [_]
   (compile-java nil)

--- a/deps.edn
+++ b/deps.edn
@@ -23,6 +23,10 @@
           slipset/deps-deploy {:mvn/version "0.2.0"}}
    :ns-default build}
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.09.08"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.10.05"}}
               :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
-              :main-opts ["-m" "clj-kondo.main"]}}}
+              :main-opts ["-m" "clj-kondo.main"]}
+  :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.3.0"}}
+             :main-opts ["-m" "eastwood.lint" {:source-paths ["src/clojure"]
+                                               :test-paths ["test"]
+                                               :add-linters [:performance]}]}}}

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -94,9 +94,12 @@ $ bb test --clj-version 1.9
 ----
 (defaults to `1.8`, specify `:all` to test against all supported Clojure versions)
 
-Our CI workflow lints sources with clj-kondo, and you can too!
+Our CI workflow lints sources with clj-kondo, and eastwood - and you can too!
 
 [source,shell]
 ----
-$ bb lint
+$ bb lint-kondo
+$ bb lint-eastwood
 ----
+
+Or to run both: `bb lint`

--- a/src/clojure/clj_yaml/core.clj
+++ b/src/clojure/clj_yaml/core.clj
@@ -123,8 +123,8 @@
           ;; TODO: unsafe marked constructor
           :else (SafeConstructor. loader))
 
-        dumper (make-dumper-options dumper-options)]
-    (Yaml. constructor (Representer.) dumper loader)))
+        dumper-opts (make-dumper-options dumper-options)]
+    (Yaml. constructor (Representer. dumper-opts) dumper-opts loader)))
 
 (defrecord Marked
   [start end unmark])


### PR DESCRIPTION
bb lint task now invokes lint-kondo and lint-eastwood tasks.

CI updated to also run eastwood.

A few clj-kondo linters enabled.

Address Eastwood finding about deprecated SnakeYAML class usage.

Closes #76
Closes #77