### PR TITLE
Ignore CVE-2022-1471

### DIFF
--- a/nvd_check_helper_project/suppressions.xml
+++ b/nvd_check_helper_project/suppressions.xml
@@ -7,4 +7,8 @@
     <filePath regex="true">.*\bsnakeyaml-1.33.jar</filePath>
     <cve>CVE-2022-38752</cve>
   </suppress>
+  <suppress>
+    <filePath regex="true">.*\bsnakeyaml-1.33.jar</filePath>
+    <cve>CVE-2022-1471</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
clj-yaml is not affected by this CVE as we use the `SafeConstructor`