### PR TITLE
Upgrade to SnakeYAML 2.1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,15 +22,17 @@ Clj-yaml makes use of SnakeYAML, please also refer to the https://bitbucket.org/
 ** Added `:code-point-limit` option to accept bigger documents
 (https://github.com/clj-commons/clj-yaml/issues/94[#94])
 (https://github.com/pitalig[@pitalig])
+* Dependencies
+** Bump `org.flatland/ordered` to `1.15.11`
+(https://github.com/clj-commons/clj-yaml/issues/98[#98])
+(https://github.com/borkdude[@borkdude])
+** Bump `org.yaml/snakeyaml` to `2.1`
+(https://github.com/clj-commons/clj-yaml/issues/86[#86])
+(https://github.com/lead[@lread])
 * Quality
 ** Stop using deprecated SnakeYAML Representer constructor
 (https://github.com/clj-commons/clj-yaml/issues/76[#76])
 (https://github.com/lead[@lread])
-
-** Bump `org.flatland/ordered` to `1.15.11`
-(https://github.com/clj-commons/clj-yaml/issues/98[#98])
-(https://github.com/borkdude[@borkdude])
-
 ** Add Eastwood linting as lint-eastwood bb task and to CI
 (https://github.com/clj-commons/clj-yaml/issues/77[#77])
 (https://github.com/lead[@lread])

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src/clojure" "target/classes"]
- :deps {org.yaml/snakeyaml {:mvn/version "1.33"}
+ :deps {org.yaml/snakeyaml {:mvn/version "2.0"}
         org.flatland/ordered {:mvn/version "1.5.9"}}
  :deps/prep-lib {:alias :build
                  :fn compile-java

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src/clojure" "target/classes"]
- :deps {org.yaml/snakeyaml {:mvn/version "2.0"}
+ :deps {org.yaml/snakeyaml {:mvn/version "2.1"}
         org.flatland/ordered {:mvn/version "1.15.11"}}
  :deps/prep-lib {:alias :build
                  :fn compile-java

--- a/nvd_check_helper_project/suppressions.xml
+++ b/nvd_check_helper_project/suppressions.xml
@@ -19,14 +19,12 @@
     <notes><![CDATA[
     False positive, does not apply to snakeyaml at all.
     ]]> </notes>
-    <filePath regex="true">.*\bsnakeyaml-1.33.jar</filePath>
     <cve>CVE-2022-3064</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
     False positive, does not apply to snakeyaml at all.
     ]]> </notes>
-     <filePath regex="true">.*\bsnakeyaml-1.33.jar</filePath>
     <cve>CVE-2021-4235</cve>
   </suppress>
 </suppressions>

--- a/src/clojure/clj_yaml/core.clj
+++ b/src/clojure/clj_yaml/core.clj
@@ -30,7 +30,7 @@
             [flatland.ordered.set :refer (ordered-set)])
   (:import (org.yaml.snakeyaml Yaml DumperOptions DumperOptions$FlowStyle LoaderOptions)
            (org.yaml.snakeyaml.constructor Constructor SafeConstructor BaseConstructor)
-           (org.yaml.snakeyaml.inspector TrustedTagInspector)
+           (org.yaml.snakeyaml.inspector TagInspector)
            (org.yaml.snakeyaml.representer Representer)
            (org.yaml.snakeyaml.error Mark)
            (clj_yaml MarkedConstructor UnknownTagsConstructor)
@@ -101,7 +101,9 @@
     (when (instance? Boolean allow-duplicate-keys)
       (.setAllowDuplicateKeys loader allow-duplicate-keys))
     (when unsafe
-      (.setTagInspector loader (TrustedTagInspector.)))
+      (.setTagInspector loader (reify TagInspector
+                                 (isGlobalTagAllowed [_this _tag]
+                                   true))))
     loader))
 
 (defn make-yaml

--- a/src/clojure/clj_yaml/core.clj
+++ b/src/clojure/clj_yaml/core.clj
@@ -30,6 +30,7 @@
             [flatland.ordered.set :refer (ordered-set)])
   (:import (org.yaml.snakeyaml Yaml DumperOptions DumperOptions$FlowStyle LoaderOptions)
            (org.yaml.snakeyaml.constructor Constructor SafeConstructor BaseConstructor)
+           (org.yaml.snakeyaml.inspector TrustedTagInspector)
            (org.yaml.snakeyaml.representer Representer)
            (org.yaml.snakeyaml.error Mark)
            (clj_yaml MarkedConstructor UnknownTagsConstructor)
@@ -89,7 +90,7 @@
 
   Returns internal SnakeYAML loader options.
   See [[parse-string]] for description of options."
-  ^LoaderOptions [& {:keys [max-aliases-for-collections allow-recursive-keys allow-duplicate-keys nesting-depth-limit]}]
+  ^LoaderOptions [& {:keys [max-aliases-for-collections allow-recursive-keys allow-duplicate-keys nesting-depth-limit unsafe]}]
   (let [loader (default-loader-options)]
     (when nesting-depth-limit
       (.setNestingDepthLimit loader nesting-depth-limit))
@@ -99,6 +100,8 @@
       (.setAllowRecursiveKeys loader allow-recursive-keys))
     (when (instance? Boolean allow-duplicate-keys)
       (.setAllowDuplicateKeys loader allow-duplicate-keys))
+    (when unsafe
+      (.setTagInspector loader (TrustedTagInspector.)))
     loader))
 
 (defn make-yaml
@@ -111,7 +114,8 @@
   (let [loader (make-loader-options :max-aliases-for-collections max-aliases-for-collections
                                     :allow-recursive-keys allow-recursive-keys
                                     :allow-duplicate-keys allow-duplicate-keys
-                                    :nesting-depth-limit nesting-depth-limit)
+                                    :nesting-depth-limit nesting-depth-limit
+                                    :unsafe unsafe)
         ^BaseConstructor constructor
         (cond
           unsafe (Constructor. loader)

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -404,7 +404,7 @@ sequence: !CustomSequence
             :sequence {:tag "!CustomSequence" :value ["a" "b" "z"]}}
            (parse-string yaml-with-unknown-tags :unknown-tag-fn identity)))
     (is (= {:base-12 12 :base-10 "10"}
-           (parse-string "{base-12: !Base12 10, base-10: !Base10 10}"
+           (parse-string "{base-12: !Base12 10, base-10: !Base10 10} "
                          :unknown-tag-fn (fn [{:keys [tag value]}]
                                            (if (= "!Base12" tag)
                                              (Integer/parseInt value 12) value)))))))
@@ -417,10 +417,10 @@ sequence: !CustomSequence
 (def dangerous-yaml "!!javax.script.ScriptEngineManager [!!java.net.URLClassLoader [[!!java.net.URL [\"very-bad-badness-here\"]]]]")
 
 (deftest unsafe-deny-test
-  (is (thrown-with-msg? YAMLException #"(?m).*could not.*constructor.*ScriptEngineManager"
+  (is (thrown-with-msg? YAMLException #"(?m).*Global tag is not allowed: .*javax\.script\.ScriptEngineManager"
                         (parse-string dangerous-yaml))
       "by default, SnakeYaml stops creation of classes - malicious example")
-  (is (thrown-with-msg? YAMLException #"(?m).*could not.*constructor.*java\.lang\.Long"
+  (is (thrown-with-msg? YAMLException #"(?m).*Global tag is not allowed: .*java\.lang\.Long"
                         (parse-string "!!java.lang.Long 5"))
       "by default, SnakeYaml stops creation of classes - innocuous looking class example"))
 

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -404,7 +404,7 @@ sequence: !CustomSequence
             :sequence {:tag "!CustomSequence" :value ["a" "b" "z"]}}
            (parse-string yaml-with-unknown-tags :unknown-tag-fn identity)))
     (is (= {:base-12 12 :base-10 "10"}
-           (parse-string "{base-12: !Base12 10, base-10: !Base10 10} "
+           (parse-string "{base-12: !Base12 10, base-10: !Base10 10}"
                          :unknown-tag-fn (fn [{:keys [tag value]}]
                                            (if (= "!Base12" tag)
                                              (Integer/parseInt value 12) value)))))))


### PR DESCRIPTION
See commits for details.

Up for debate: my approach to dealing with unsafe YAML should be questioned.

An interesting alternative would be to also expose the new TagInspectors when using clj-yaml's  `:unsafe` option. But, I think (correct me if I am wrong) we might already have this feature-wise via `:unknown-tag-fn`.

Closes #86