### PR TITLE
maint: github actions deprecations

### DIFF
--- a/.github/workflows/nvd_scanner.yml
+++ b/.github/workflows/nvd_scanner.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Get Date
       id: get-date
       run: |
-        echo "name=date::$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+        echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Cache NVD Database

--- a/.github/workflows/nvd_scanner.yml
+++ b/.github/workflows/nvd_scanner.yml
@@ -15,7 +15,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup
       uses: ./.github/workflows/shared-setup

--- a/.github/workflows/nvd_scanner.yml
+++ b/.github/workflows/nvd_scanner.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Get Date
       id: get-date
       run: |
-        echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        echo "name=date::$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Cache NVD Database

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
 
       - name: Setup
         uses: ./.github/workflows/shared-setup
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
 
       - name: Setup
         uses: ./.github/workflows/shared-setup


### PR DESCRIPTION
- bump 2 to 3 to resolve deprecation warnings form GitHub
- stop specifying more than major version for 3