### PR TITLE
bump ordered to 1.15.11

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,8 +24,8 @@ Clj-yaml makes use of SnakeYAML, please also refer to the https://bitbucket.org/
 (https://github.com/clj-commons/clj-yaml/issues/76[#76])
 (https://github.com/lead[@lread])
 
-** Bump `org.flatland/ordered` to `1.15.10`
-(https://github.com/clj-commons/clj-yaml/issues/96[#96])
+** Bump `org.flatland/ordered` to `1.15.11`
+(https://github.com/clj-commons/clj-yaml/issues/98[#98])
 (https://github.com/borkdude[@borkdude])
 
 ** Add Eastwood linting as lint-eastwood bb task and to CI

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src/clojure" "target/classes"]
  :deps {org.yaml/snakeyaml {:mvn/version "1.33"}
-        org.flatland/ordered {:mvn/version "1.15.10"}}
+        org.flatland/ordered {:mvn/version "1.15.11"}}
  :deps/prep-lib {:alias :build
                  :fn compile-java
                  :ensure "target/classes"}


### PR DESCRIPTION
This picks ups borkdude's fix for ordered GraalVM native-image bloat.

Closes #98