### PR TITLE
git ignore: ./fiddle dir [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target
 /.calva
 .cpcache
 /.eastwood
+/fiddle


### PR DESCRIPTION
It's nice to have a dir to fiddle around in that will be ignored by git.