### PR TITLE
Use release version 11 for JDK20 and higher.

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -42,7 +42,7 @@
                         :javac-opts javac-opts}
                  (> major 8)
                  ;; --release replaces -source and -target opts for > jdk8
-                 (update :javac-opts #(conj % "--release" "8")))))))
+                 (update :javac-opts #(conj % "--release" (if (<= 20 major) "11" "8"))))))))
 
 
 (defn compile-clj-for-native-test


### PR DESCRIPTION
Release version 8 is obsolete and causes warning when compiling on JDK20 and higher, which together with -Werror fails the compile-java step. Hence we target version 11 for JDK20 and higher.