### PR TITLE
maint: bump deps (ci and dev support only)

### DIFF
--- a/.github/workflows/nvd_scanner.yml
+++ b/.github/workflows/nvd_scanner.yml
@@ -15,7 +15,7 @@ jobs:
     environment: nvd
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup
       uses: ./.github/workflows/shared-setup
@@ -29,7 +29,7 @@ jobs:
       shell: bash
 
     - name: Cache NVD Database
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /home/runner/.nvd-cache/
         key: nvd-cache-we-are-happy-to-share-across-branches-${{ steps.get-date.outputs.date }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup
       uses: ./.github/workflows/shared-setup

--- a/.github/workflows/shared-setup/action.yml
+++ b/.github/workflows/shared-setup/action.yml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Clojure deps cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository
@@ -24,14 +24,14 @@ runs:
         restore-keys: cljdeps-
 
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: ${{ inputs.jdk }}
       if: inputs.jdk != 'skip'
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@12.5
       with:
         cli: 'latest'
         bb: 'latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/workflows/shared-setup
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/workflows/shared-setup
@@ -44,13 +44,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [{name: 'windows', shell: 'pwsh'}, {name: 'ubuntu', shell: 'bash'}]
-        jdk: ['8', '11', '17']
+        jdk: ['8', '11', '17', '21']
 
     name: ${{matrix.os.name}} jdk ${{ matrix.jdk }}
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup
       uses: ./.github/workflows/shared-setup
@@ -74,14 +74,13 @@ jobs:
           - { name: 'graalvm', short-name: 'graal' }
           - { name: 'graalvm-community', short-name: 'graalce' }
         java-version:
-          - '17.0.8'
-          - '20.0.2'
+          - '21.0.2'
 
     name: ${{matrix.os.name}} ${{matrix.distribution.short-name}} ${{matrix.java-version}}
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup
       uses: ./.github/workflows/shared-setup

--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,7 @@
 {:paths ["script" "build"]
  :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
-        io.github.babashka/neil {:git/tag "v0.1.60" :git/sha "19bc12d"}
+        io.github.babashka/neil {:git/tag "v0.2.63" :git/sha "076fb83"}
         version-clj/version-clj {:mvn/version "2.0.2"}}
  :tasks {;; setup
          :requires ([babashka.fs :as fs]

--- a/deps.edn
+++ b/deps.edn
@@ -23,15 +23,15 @@
    :extra-deps {com.github.clj-easy/graal-build-time {:mvn/version "1.0.5"}}}
   :build
   {:extra-paths ["build"]
-   :deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}
-          slipset/deps-deploy {:mvn/version "0.2.1"}
-          babashka/fs {:mvn/version "0.4.19"}}
+   :deps {io.github.clojure/tools.build {:mvn/version "0.9.6"}
+          slipset/deps-deploy {:mvn/version "0.2.2"}
+          babashka/fs {:mvn/version "0.5.20"}}
    :ns-default build}
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.07.13"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.02.12"}}
               :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
               :main-opts ["-m" "clj-kondo.main"]}
-  :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.0"}}
+  :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.2"}}
              :main-opts ["-m" "eastwood.lint" {:source-paths ["src/clojure"]
                                                :test-paths ["test"]
                                                :add-linters [:performance]}]}}}


### PR DESCRIPTION
Of note:
ci: add jdk 21 to jvm test matrix
ci: test against current graal latest only