### PR TITLE
maint: bump deps (ci and dev support only)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,8 +75,9 @@ jobs:
           - { name: 'graalvm-community', short-name: 'graalce' }
         java-version:
           - '21.0.2'
+        clojure-version: [ '1.11', '1.12' ]
 
-    name: ${{matrix.os.name}} ${{matrix.distribution.short-name}} ${{matrix.java-version}}
+    name: ${{matrix.os.name}} ${{matrix.distribution.short-name}} jdk${{matrix.java-version}} clj${{ matrix.clojure-version }}
 
     steps:
     - name: Checkout
@@ -96,4 +97,4 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run native tests
-      run: bb test-native
+      run: bb test-native --clj-version ${{ matrix.clojure-version }}

--- a/build.clj
+++ b/build.clj
@@ -47,7 +47,7 @@
 
 (defn compile-clj-for-native-test
   "We compile our tests against our local jar."
-  [_]
+  [{:keys [clj-version-alias]}]
   (println "compile-clj to:" native-test-class-dir)
   (let [jars (->> (fs/glob "target" "*.jar") (mapv str))]
     (when (not= (count jars) 1)
@@ -55,7 +55,7 @@
                               (if (seq jars) jars "none"))
                       {})))
     (let [jar (first jars)
-          basis (b/create-basis {:aliases [:native-test :test]
+          basis (b/create-basis {:aliases [:native-test :test clj-version-alias]
                                  :extra {:deps {'clj-commons/clj-yaml {:local/root jar}}}})]
       (println "Using jar:" jar)
       ;; share the classpath for native-image to use in test-native bb task

--- a/deps.edn
+++ b/deps.edn
@@ -12,24 +12,25 @@
   :1.8 {:override-deps {org.clojure/clojure {:mvn/version "1.8.0"}}}
   :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
-  :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}}
+  :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}}
+  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-alpha9"}}}
   :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts ["-m" "cognitect.test-runner"]}
   :native-test
-  {:override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+  {:override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}
    :replace-paths ["target/native-test-classes"]
    :extra-deps {com.github.clj-easy/graal-build-time {:mvn/version "1.0.5"}}}
   :build
   {:extra-paths ["build"]
-   :deps {io.github.clojure/tools.build {:mvn/version "0.9.6"}
+   :deps {io.github.clojure/tools.build {:mvn/version "0.10.0"}
           slipset/deps-deploy {:mvn/version "0.2.2"}
           babashka/fs {:mvn/version "0.5.20"}}
    :ns-default build}
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.02.12"}}
-              :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.03.05"}}
+              :override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}
               :main-opts ["-m" "clj-kondo.main"]}
   :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.2"}}
              :main-opts ["-m" "eastwood.lint" {:source-paths ["src/clojure"]

--- a/script/test_clj.clj
+++ b/script/test_clj.clj
@@ -4,7 +4,7 @@
             [lread.status-line :as status]))
 
 (defn -main [& args]
-  (let [all-clojure-versions ["1.8" "1.9" "1.10" "1.11"]
+  (let [all-clojure-versions ["1.8" "1.9" "1.10" "1.11" "1.12"]
         valid-clj-version-opt-values (conj all-clojure-versions ":all")
         spec {:clj-version
               {:ref "<version>"


### PR DESCRIPTION
Of note:
- now also testing against clojure 1.12 for jvm and native tests