### PR TITLE
ci: vulnerability scan: rebump dependency-check

### DIFF
--- a/nvd_check_helper_project/deps.edn
+++ b/nvd_check_helper_project/deps.edn
@@ -4,4 +4,4 @@
         #_:clj-kondo/ignore
         {:mvn/version "RELEASE"}
         ;; temporarily try bumping transitive dep to current release
-        org.owasp/dependency-check-core {:mvn/version "10.0.0"}}}
+        org.owasp/dependency-check-core {:mvn/version "10.0.1"}}}


### PR DESCRIPTION
This gets rid of log lines like:
```
[2024-07-02 03:51:36.108] ERROR CveDB - Updating CVE: CVE-2024-5635
```
Which were not errors but debug log lines left in by accident:

- https://github.com/jeremylong/DependencyCheck/issues/6746#issuecomment-2202578571
- https://github.com/jeremylong/DependencyCheck/commit/8c731cd63f6323a2be072c31530df0284e387f4d