### PR TITLE
ci: vulnerability scan: bump dependency check

### DIFF
--- a/nvd_check_helper_project/deps.edn
+++ b/nvd_check_helper_project/deps.edn
@@ -4,4 +4,4 @@
         #_:clj-kondo/ignore
         {:mvn/version "RELEASE"}
         ;; temporarily try bumping transitive dep to current release
-        org.owasp/dependency-check-core {:mvn/version "10.0.1"}}}
+        org.owasp/dependency-check-core {:mvn/version "10.0.2"}}}


### PR DESCRIPTION
Apparently 10.0.2 is a mandatory update.