### PR TITLE
test & ci: bump deps, tweak pubcheck

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
           - { name: 'graalvm', short-name: 'graal' }
           - { name: 'graalvm-community', short-name: 'graalce' }
         java-version:
-          - '22.0.1'
+          - '22.0.2'
         clojure-version: [ '1.11', '1.12' ]
 
     name: ${{matrix.os.name}} ${{matrix.distribution.short-name}} jdk${{matrix.java-version}} clj${{ matrix.clojure-version }}

--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,7 @@
 {:paths ["script" "build"]
  :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
-        io.github.babashka/neil {:git/tag "v0.3.65" :git/sha "9a79582"}
+        io.github.babashka/neil {:git/tag "v0.3.67" :git/sha "054ca51"}
         version-clj/version-clj {:mvn/version "2.0.2"}}
  :tasks {;; setup
          :requires ([babashka.fs :as fs]

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
   :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
   :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
-  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-beta1"}}}
+  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-beta2"}}}
   :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
@@ -24,7 +24,7 @@
    :extra-deps {com.github.clj-easy/graal-build-time {:mvn/version "1.0.5"}}}
   :build
   {:extra-paths ["build"]
-   :deps {io.github.clojure/tools.build {:mvn/version "0.10.4"}
+   :deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
           slipset/deps-deploy {:mvn/version "0.2.2"}
           babashka/fs {:mvn/version "0.5.21"}}
    :ns-default build}
@@ -32,7 +32,7 @@
   :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.24"}}
               :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
               :main-opts ["-m" "clj-kondo.main"]}
-  :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.2"}}
+  :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}
              :main-opts ["-m" "eastwood.lint" {:source-paths ["src/clojure"]
                                                :test-paths ["test"]
                                                :add-linters [:performance]}]}}}

--- a/nvd_check_helper_project/deps.edn
+++ b/nvd_check_helper_project/deps.edn
@@ -4,4 +4,4 @@
         #_:clj-kondo/ignore
         {:mvn/version "RELEASE"}
         ;; temporarily try bumping transitive dep to current release
-        org.owasp/dependency-check-core {:mvn/version "10.0.2"}}}
+        org.owasp/dependency-check-core {:mvn/version "10.0.3"}}}


### PR DESCRIPTION
Of note:
- clojure 1.12 beta2!
- bb `pubcheck` task can now run checks on unpushed branch