### PR TITLE
test & ci: bump deps

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -2,7 +2,7 @@
  :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
         io.github.babashka/neil {:git/tag "v0.3.67" :git/sha "054ca51"}
-        version-clj/version-clj {:mvn/version "2.0.2"}}
+        version-clj/version-clj {:mvn/version "2.0.3"}}
  :tasks {;; setup
          :requires ([babashka.fs :as fs]
                     [clojure.string :as string]

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,7 @@
   :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
   :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
-  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-beta2"}}}
+  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}}
   :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
@@ -26,10 +26,10 @@
   {:extra-paths ["build"]
    :deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
           slipset/deps-deploy {:mvn/version "0.2.2"}
-          babashka/fs {:mvn/version "0.5.21"}}
+          babashka/fs {:mvn/version "0.5.22"}}
    :ns-default build}
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.24"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.08.29"}}
               :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
               :main-opts ["-m" "clj-kondo.main"]}
   :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}

--- a/script/lint.clj
+++ b/script/lint.clj
@@ -23,10 +23,8 @@
                    with-out-str
                    string/trim)
         bb-cp (bbcp/get-classpath)]
-    (status/line :detail "- copying configs")
-    (t/clojure "-M:clj-kondo --skip-lint --copy-configs --lint" clj-cp bb-cp)
-    (status/line :detail "- creating cache")
-    (t/clojure "-M:clj-kondo --dependencies --lint" clj-cp bb-cp)))
+    (status/line :detail "- copying configs and creating cache")
+    (t/clojure "-M:clj-kondo --skip-lint --copy-configs --dependencies --lint" clj-cp bb-cp)))
 
 (defn- check-cache [{:keys [rebuild]}]
   (status/line :head "clj-kondo: cache check")
@@ -50,7 +48,7 @@
   (status/line :head "clj-kondo: linting")
   (let [{:keys [exit]}
         (t/clojure {:continue true}
-                   "-M:clj-kondo --lint src/clojure test build script deps.edn bb.edn")]
+                   "-M:clj-kondo --parallel --lint src/clojure test build script deps.edn bb.edn")]
     (cond
       (= 2 exit) (status/die exit "clj-kondo found one or more lint errors")
       (= 3 exit) (status/die exit "clj-kondo found one or more lint warnings")


### PR DESCRIPTION
Of note:
- clojure 1.12.0! woot!
- new version of clj-kondo! Take advantage of clj-kondo's new ability to copy configs and create cache at same time.