### PR TITLE
dev & ci: more clojure 1.12, add outdated task

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
           - { name: 'graalvm-community', short-name: 'graalce' }
         java-version:
           - '22.0.2'
-        clojure-version: [ '1.11', '1.12' ]
+        clojure-version: [ '1.12' ]
 
     name: ${{matrix.os.name}} ${{matrix.distribution.short-name}} jdk${{matrix.java-version}} clj${{ matrix.clojure-version }}
 

--- a/bb.edn
+++ b/bb.edn
@@ -47,6 +47,9 @@
          lint
          {:doc "Run all lints"
           :depends [lint-kondo lint-eastwood]}
+         outdated
+         {:doc "report on outdated dependencies"
+          :task (clojure {:continue true} "-M:outdated")}
          nvd-scan
          {:doc "Check for security vulnerabilities in dependencies"
           :task (let [cp (with-out-str (clojure "-Spath"))]

--- a/deps.edn
+++ b/deps.edn
@@ -12,14 +12,14 @@
   :1.8 {:override-deps {org.clojure/clojure {:mvn/version "1.8.0"}}}
   :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
-  :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
+  :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
   :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}}
   :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts ["-m" "cognitect.test-runner"]}
   :native-test
-  {:override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
+  {:override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
    :replace-paths ["target/native-test-classes"]
    :extra-deps {com.github.clj-easy/graal-build-time {:mvn/version "1.0.5"}}}
   :build
@@ -30,9 +30,14 @@
    :ns-default build}
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
   :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.08.29"}}
-              :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
+              :override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
               :main-opts ["-m" "clj-kondo.main"]}
   :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}
              :main-opts ["-m" "eastwood.lint" {:source-paths ["src/clojure"]
                                                :test-paths ["test"]
-                                               :add-linters [:performance]}]}}}
+                                               :add-linters [:performance]}]}
+  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.9.1227"}
+                          org.clojure/clojure {:mvn/version "1.12.0"}
+                          org.slf4j/slf4j-simple {:mvn/version "2.0.16"} ;; to rid ourselves of logger warnings
+                          }
+             :main-opts ["-m" "antq.core"]}}}


### PR DESCRIPTION
Since clojure 1.12 has gone gold, we can reduce our test set for native-image to 1.12 only (was testing against 1.11 and 1.12).

Also use 1.12 as our clojure version when we need to specify it (instead of 1.11).

Also: add `outdated` bb task for convenience and consistency with other projects I maintain.