### PR TITLE
Set indent-with-indicator before indicator-indent in dumper options

### DIFF
--- a/src/clojure/clj_yaml/core.clj
+++ b/src/clojure/clj_yaml/core.clj
@@ -72,10 +72,10 @@
       (.setDefaultFlowStyle dumper (flow-styles flow-style)))
     (when indent
       (.setIndent dumper indent))
-    (when indicator-indent
-      (.setIndicatorIndent dumper indicator-indent))
     (when indent-with-indicator
       (.setIndentWithIndicator dumper indent-with-indicator))
+    (when indicator-indent
+      (.setIndicatorIndent dumper indicator-indent))
     dumper))
 
 (defn default-loader-options

--- a/test/clj_yaml/core_test.clj
+++ b/test/clj_yaml/core_test.clj
@@ -411,7 +411,20 @@ lol: yolo")
                             :dumper-options {:indent 5
                                              :indicator-indent 2
                                              :indent-with-indicator true
-                                             :flow-style :block})))))
+                                             :flow-style :block})))
+    (is (= (str "todo:\n"
+                ;12
+                "  issues:\n"
+                ;; 12
+                "    - name: Fix all the things\n"
+                "      responsible:\n"
+                ;;     12
+                "        name: Rita\n")
+           (generate-string (parse-string indent-yaml)
+             :dumper-options {:indent 2
+                              :indicator-indent 2
+                              :indent-with-indicator true
+                              :flow-style :block})))))
 
 (def yaml-with-unknown-tags "---
 scalar: !CustomScalar some-scalar


### PR DESCRIPTION
This change allows setting `:indent` and `:indicator-indent` to the same value.

Calling `setIndicatorIndent` throws `org.yaml.snakeyaml.error.YAMLException` with the message `"Indicator indent must be smaller then indent."` when `(<= indent indicator-indent)`. If `setIndentWithIndicator` is `true` when `setIndicatorIndent` is called this is not an issue. 

So this fix changes the order that we configure the dumper options in order to support the original usecase mentioned in https://github.com/clj-commons/clj-yaml/issues/136 that motivated `:indent-with-indicator`.

Should resolve https://github.com/clj-commons/clj-yaml/issues/31 and https://github.com/clj-commons/clj-yaml/discussions/37 also.